### PR TITLE
feat: implement rocket add handler command

### DIFF
--- a/.github/workflows/run-project.yml
+++ b/.github/workflows/run-project.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Verify application execution pg
         if: success()
         run: |
-          rm -rf pg
+          rm -rf samplepg
           go run main.go new -c rocket-database-pg.yaml
-          cd pg && go mod tidy && go mod vendor
+          cd samplepg && go mod tidy && go mod vendor
       - name: Verify application execution docker
         if: success()
         run: |
@@ -68,4 +68,4 @@ jobs:
       - name: Remove all dummy data
         if: success()
         run: |
-          rm -rf basic cacher mongodb mysql pg dcc r1
+          rm -rf basic cacher mongodb mysql samplepg dcc r1

--- a/builder/add_handler.go
+++ b/builder/add_handler.go
@@ -1,0 +1,101 @@
+package builder
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/muhfaris/rocket/builder/hexagonal"
+	"github.com/muhfaris/rocket/config"
+	libos "github.com/muhfaris/rocket/shared/os"
+	"github.com/muhfaris/rocket/shared/templates"
+	"github.com/spf13/viper"
+)
+
+// AddHandler generates a single handler for the given operationId
+// in the specified project directory using its rocket.yaml config.
+func AddHandler(projectDir, openapiFilePath, operationID, ignoreDataResponse string) error {
+	// Load OpenAPI spec
+	content, doc, err := libos.LoadOpenapi(openapiFilePath)
+	if err != nil {
+		return fmt.Errorf("load openapi: %w", err)
+	}
+
+	// Read rocket.yaml from the project directory
+	// The config is expected at <projectDir>/rocket.yaml
+	cfg, err := loadRocketConfig(projectDir)
+	if err != nil {
+		return fmt.Errorf("load rocket config: %w", err)
+	}
+
+	projectName := cfg.App.Project
+	packagePath := cfg.App.Package
+
+	if projectName == "" || packagePath == "" {
+		return fmt.Errorf("rocket.yaml must have 'app.project' and 'app.package' set")
+	}
+
+	// Set arch layout for template resolution
+	archLayout := cfg.App.Arch
+	if archLayout == "" {
+		archLayout = "hexagonal"
+	}
+	templates.SetArchLayout(archLayout)
+
+	// Build the hexagonal project context
+	based := hexagonal.Based{
+		Project: hexagonal.BaseProject{
+			AppName:     projectName,
+			ProjectName: projectName,
+			PackagePath: packagePath,
+		},
+		Package: hexagonal.BasePackage{},
+	}
+
+	ignoreDataResponseBool := ignoreDataResponse == "true"
+	if ignoreDataResponse == "" {
+		ignoreDataResponseBool = false
+	}
+
+	project := hexagonal.NewProject(doc, &hexagonal.Config{
+		Based:              based,
+		ProjectName:        projectName,
+		CacheParam:         cfg.App.Cache,
+		DBParam:            cfg.App.Database,
+		IgnoreDataResponse: ignoreDataResponseBool,
+	})
+
+	// Copy the OpenAPI spec into the project's spec/ directory if different
+	// (only needed if user is pointing to an updated spec)
+	specDir := fmt.Sprintf("%s/spec", projectName)
+	if err := os.MkdirAll(specDir, os.ModePerm); err != nil {
+		return fmt.Errorf("ensure spec dir: %w", err)
+	}
+	specFile := fmt.Sprintf("%s/openapi.yaml", specDir)
+	if err := libos.CreateFile(specFile, content); err != nil {
+		return fmt.Errorf("copy spec: %w", err)
+	}
+
+	// Delegate to hexagonal handler generation
+	return project.AddHandler(operationID)
+}
+
+// loadRocketConfig reads the rocket.yaml from a project directory.
+func loadRocketConfig(projectDir string) (config.Config, error) {
+	var cfg config.Config
+
+	viperInstance := viper.New()
+	viperInstance.SetConfigName("rocket")
+	viperInstance.SetConfigType("yaml")
+	viperInstance.AddConfigPath(projectDir)
+	viperInstance.AddConfigPath(".")
+
+	if err := viperInstance.ReadInConfig(); err != nil {
+		return cfg, fmt.Errorf("read rocket.yaml in %s: %w", projectDir, err)
+	}
+
+	if err := viperInstance.Unmarshal(&cfg); err != nil {
+		return cfg, fmt.Errorf("parse rocket.yaml: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/builder/add_handler.go
+++ b/builder/add_handler.go
@@ -41,11 +41,12 @@ func AddHandler(projectDir, openapiFilePath, operationID, ignoreDataResponse str
 	}
 	templates.SetArchLayout(archLayout)
 
-	// Build the hexagonal project context
+	// Build the hexagonal project context.
+	// Use projectDir as the project root so all generated paths are absolute.
 	based := hexagonal.Based{
 		Project: hexagonal.BaseProject{
 			AppName:     projectName,
-			ProjectName: projectName,
+			ProjectName: projectDir,
 			PackagePath: packagePath,
 		},
 		Package: hexagonal.BasePackage{},
@@ -58,15 +59,14 @@ func AddHandler(projectDir, openapiFilePath, operationID, ignoreDataResponse str
 
 	project := hexagonal.NewProject(doc, &hexagonal.Config{
 		Based:              based,
-		ProjectName:        projectName,
+		ProjectName:        projectDir,
 		CacheParam:         cfg.App.Cache,
 		DBParam:            cfg.App.Database,
 		IgnoreDataResponse: ignoreDataResponseBool,
 	})
 
-	// Copy the OpenAPI spec into the project's spec/ directory if different
-	// (only needed if user is pointing to an updated spec)
-	specDir := fmt.Sprintf("%s/spec", projectName)
+	// Copy the OpenAPI spec into the project's spec/ directory
+	specDir := fmt.Sprintf("%s/spec", projectDir)
 	if err := os.MkdirAll(specDir, os.ModePerm); err != nil {
 		return fmt.Errorf("ensure spec dir: %w", err)
 	}

--- a/builder/hexagonal/add_handler.go
+++ b/builder/hexagonal/add_handler.go
@@ -1,0 +1,396 @@
+package hexagonal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/muhfaris/rocket/helper/ui"
+	"github.com/muhfaris/rocket/shared/generate"
+	libcase "github.com/muhfaris/rocket/shared/case"
+	liboas "github.com/muhfaris/rocket/shared/oas"
+	libos "github.com/muhfaris/rocket/shared/os"
+	"github.com/muhfaris/rocket/shared/templates"
+	"github.com/muhfaris/rocket/shared/utils"
+)
+
+
+
+// findOperationById locates a path+method+operation by operationId in the OpenAPI doc.
+func (p *Project) findOperationById(operationID string) (path string, method string, operation *openapi3.Operation, err error) {
+	for pPath, pathItem := range p.doc.Paths.Map() {
+		for m, op := range pathItem.Operations() {
+			if op.OperationID == operationID || strings.HasPrefix(op.OperationID, operationID+"::") {
+				return pPath, m, op, nil
+			}
+		}
+	}
+	return "", "", nil, fmt.Errorf("operationId %q not found in OpenAPI spec", operationID)
+}
+
+
+// AddHandler generates handler, presenter, domain, service port, service impl,
+// and router entries for a single operationId in an existing generated project.
+func (p *Project) AddHandler(operationID string) error {
+	path, method, operation, err := p.findOperationById(operationID)
+	if err != nil {
+		return err
+	}
+
+	if len(operation.Tags) == 0 {
+		return fmt.Errorf("operation %q must have at least one tag", operationID)
+	}
+
+	fmt.Printf(" %s Adding handler for %s %s\n", ui.LineOnProgress, method, path)
+
+	// --- Prepare handler data ---
+	opsID, serviceName := getOperationIDInfo(operation)
+	_, handlerStructName := libcase.Format(opsID)
+
+	handlerData := &HandlerData{
+		PackagePath: p.based.Project.PackagePath,
+		HandlerName: opsID,
+		Structs:     make([]Struct, 0),
+		HasParams:   false,
+		HasQuery:    false,
+		HasBody:     false,
+		ParamsData:  ParamsData{},
+		QueryData:   QueryData{},
+		BodyData:    BodyData{},
+		DomainModel: Struct{StructName: handlerStructName},
+	}
+
+	err = handlerData.Generate(method, operation)
+	if err != nil {
+		return fmt.Errorf("generate handler data: %w", err)
+	}
+
+	// service handler
+	svcMethodFunc := strings.ReplaceAll(opsID, "Handler", "")
+	handlerService := PortServiceMethods{
+		MethodName:  svcMethodFunc,
+		ReturnTypes: []PortServiceReturnType{{Type: "error"}},
+	}
+
+	if handlerData.HasStructsResponse {
+		handlerService = PortServiceMethods{
+			MethodName: svcMethodFunc,
+			ReturnTypes: []PortServiceReturnType{
+				{Type: fmt.Sprintf("domain.%s", handlerData.DomainModel.StructName)},
+				{Type: "error"},
+			},
+		}
+		handlerData.ServiceHasReturn = true
+	}
+
+	handlerService.Params = append(handlerService.Params, PortServiceMethodParams{
+		Name: "payload",
+		Type: fmt.Sprintf("domain.%s", handlerData.DomainModel.StructName),
+	})
+
+	handlerData.HasService = true
+	handlerData.Service = handlerService
+	handlerData.ServiceName = serviceName
+	if handlerData.ServiceName == "" {
+		handlerData.ServiceName = "AppSvc"
+	}
+
+	// annotation
+	annotation, err := liboas.CreateSwaggerAnnotation(path, method, operation)
+	if err != nil {
+		return err
+	}
+	handlerData.Annotation = annotation
+
+	// --- Determine directories from the existing project ---
+	projectName := p.based.Project.ProjectName
+	handlerDir := fmt.Sprintf("%s/internal/adapter/inbound/rest/router/v1/handler", projectName)
+	presenterDir := fmt.Sprintf("%s/internal/adapter/inbound/rest/router/v1/presenter", projectName)
+	domainDir := fmt.Sprintf("%s/internal/core/domain", projectName)
+	serviceDir := fmt.Sprintf("%s/internal/core/service", projectName)
+	portServiceDir := fmt.Sprintf("%s/internal/core/port/inbound/service", projectName)
+	groupRouterFile := fmt.Sprintf("%s/internal/adapter/inbound/rest/router/group/v1.go", projectName)
+
+	// --- 1. Generate handler file ---
+	fmt.Printf("  %s handler file\n", ui.LineOnProgress)
+	err = p.createHandlerFile(handlerDir, handlerData)
+	if err != nil {
+		return fmt.Errorf("create handler file: %w", err)
+	}
+
+	// --- 2. Generate presenter file ---
+	fmt.Printf("  %s presenter file\n", ui.LineOnProgress)
+	err = p.createPresenterFile(presenterDir, handlerData)
+	if err != nil {
+		return fmt.Errorf("create presenter file: %w", err)
+	}
+
+	// --- 3. Domain model (append or create) ---
+	fmt.Printf("  %s domain model\n", ui.LineOnProgress)
+	tag := strings.ToLower(operation.Tags[0])
+	domainFilename := fmt.Sprintf("%s.go", libcase.ToSnakeCase(tag))
+	domainFilepath := fmt.Sprintf("%s/%s", domainDir, domainFilename)
+
+	err = p.appendDomainModels(domainFilepath, handlerData)
+	if err != nil {
+		return fmt.Errorf("domain model: %w", err)
+	}
+
+	// --- 4. Port service (interface) ---
+	fmt.Printf("  %s port service interface\n", ui.LineOnProgress)
+	svcLower := strings.ToLower(handlerData.ServiceName)
+	portServiceFilepath := fmt.Sprintf("%s/%s.go", portServiceDir, svcLower)
+
+	err = p.appendPortServiceMethod(portServiceFilepath, handlerData.ServiceName, handlerService)
+	if err != nil {
+		return fmt.Errorf("port service: %w", err)
+	}
+
+	// --- 5. Service implementation ---
+	fmt.Printf("  %s service implementation\n", ui.LineOnProgress)
+	serviceFilepath := fmt.Sprintf("%s/%s.go", serviceDir, svcLower)
+
+	err = p.appendServiceMethod(serviceFilepath, handlerData.ServiceName, handlerService)
+	if err != nil {
+		return fmt.Errorf("service impl: %w", err)
+	}
+
+	// --- 6. Group router ---
+	fmt.Printf("  %s router registration\n", ui.LineOnProgress)
+	err = p.appendRouterRegistration(groupRouterFile, path, method, opsID, operation)
+	if err != nil {
+		return fmt.Errorf("router: %w", err)
+	}
+
+	fmt.Printf(" %s Done. Handler '%s' added to project '%s'.\n", ui.LineLast, opsID, projectName)
+	return nil
+}
+
+
+// appendDomainModels appends new structs to an existing domain file or creates one.
+func (p *Project) appendDomainModels(domainFilepath string, handlerData *HandlerData) error {
+	domainDir := fmt.Sprintf("%s/internal/core/domain", p.based.Project.ProjectName)
+	if err := os.MkdirAll(domainDir, os.ModePerm); err != nil {
+		return fmt.Errorf("ensure domain dir: %w", err)
+	}
+
+	if _, err := os.Stat(domainFilepath); os.IsNotExist(err) {
+		// Create new domain file — filename is just the base name
+		_, filename := filepath.Split(domainFilepath)
+		dataStruct := DataDomainModel{
+			filename: filename,
+			Structs:  []Struct{handlerData.DomainModel},
+		}
+
+		raw, err := libos.ExecuteTemplate(templates.GetDomainModel(), dataStruct)
+		if err != nil {
+			return err
+		}
+		return libos.CreateFile(domainFilepath, raw)
+	}
+
+	// Append new structs to existing domain file
+	// Build the struct definition text using the same format as the template
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("\ntype %s struct {\n", handlerData.DomainModel.StructName))
+	for _, f := range handlerData.DomainModel.Fields {
+		sb.WriteString(fmt.Sprintf("\t%s %s %s\n", f.FieldName, f.FieldType, f.Tag))
+	}
+	sb.WriteString("}\n")
+
+	return generate.AppendToFile(domainFilepath, sb.String())
+}
+
+
+// appendPortServiceMethod adds a new method to an existing port service interface.
+func (p *Project) appendPortServiceMethod(filepath, serviceName string, method PortServiceMethods) error {
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		// Create new port service file
+		data := map[string]any{
+			"PackagePath": p.based.Project.PackagePath,
+			"ServiceName": serviceName,
+			"Methods":     []PortServiceMethods{method},
+		}
+
+		raw, err := libos.ExecuteTemplate(templates.GetRestPortServiceTemplate(), data)
+		if err != nil {
+			return err
+		}
+		return libos.CreateFile(filepath, raw)
+	}
+
+	// Build method signature
+	var sb strings.Builder
+	returnTypes := buildReturnTypeString(method.ReturnTypes)
+	params := buildParamString(method.Params)
+
+	sb.WriteString(fmt.Sprintf("\n\t%s(ctx context.Context%s) %s",
+		method.MethodName, params, returnTypes))
+
+	// Insert before interface closing brace
+	decl := fmt.Sprintf("type %s interface {", serviceName)
+	return generate.InsertBeforePackageCloser(filepath, decl, sb.String())
+}
+
+
+// appendServiceMethod adds a new method implementation to an existing service file.
+func (p *Project) appendServiceMethod(filepath, serviceName string, method PortServiceMethods) error {
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		// Create new service file
+		data := map[string]any{
+			"PackagePath": p.based.Project.PackagePath,
+			"ServiceName": serviceName,
+			"Methods":     []PortServiceMethods{method},
+		}
+
+		raw, err := libos.ExecuteTemplate(templates.GetServiceTemplate(), data)
+		if err != nil {
+			return err
+		}
+		return libos.CreateFile(filepath, raw)
+	}
+
+	// Build method implementation stub
+	var sb strings.Builder
+	returnTypes := buildReturnTypeString(method.ReturnTypes)
+	params := buildParamString(method.Params)
+
+	// Generate zero-value return
+	returnVals := buildReturnValues(method.ReturnTypes)
+
+	sb.WriteString(fmt.Sprintf("\nfunc (s *%s) %s(ctx context.Context%s) %s {",
+		serviceName, method.MethodName, params, returnTypes))
+	sb.WriteString(fmt.Sprintf("\n\treturn %s", returnVals))
+	sb.WriteString("\n}\n")
+
+	return generate.AppendToFile(filepath, sb.String())
+}
+
+
+// appendRouterRegistration adds a route to the group router file.
+// If the group function already exists, it adds a route line inside it.
+// Otherwise it creates a new group function and wires it into V1().
+func (p *Project) appendRouterRegistration(groupRouterFile, path, method, opsID string, operation *openapi3.Operation) error {
+	// Determine group info from x-route-group or default
+	groupRoute := "routeGroup"
+	groupRoutePath := "/"
+
+	xRouteGroupAny := operation.Extensions["x-route-group"]
+	xRouteGroup, ok := xRouteGroupAny.(string)
+	if ok && xRouteGroup != "" {
+		xRouteGroups := strings.Split(xRouteGroup, "::")
+		if len(xRouteGroups) == 2 {
+			groupRoute = xRouteGroups[0]
+			groupRoutePath = xRouteGroups[1]
+		}
+	}
+
+	routerPath := utils.ConvertBracesToColon(path)
+	methodTitle := libcase.ToTitleCase(method)
+
+	// Check if group function already exists
+	groupFuncHeader := fmt.Sprintf("func %s(r *fiber.App, h *handlerv1.Handler) {", groupRoute)
+
+	if _, err := os.Stat(groupRouterFile); os.IsNotExist(err) {
+		// Create new group router file with just this route
+		group := RouterGroup{
+			GroupName: groupRoute,
+			GroupPath: groupRoutePath,
+			Routes: []ChildRouterGroup{
+				{Method: methodTitle, Path: routerPath, Handler: opsID},
+			},
+		}
+
+		data := map[string]any{
+			"PackagePath": p.based.Project.PackagePath,
+			"AppName":     p.based.Project.AppName,
+			"Groups":      []RouterGroup{group},
+		}
+
+		raw, err := libos.ExecuteTemplate(templates.GetGroupRestTemplate(), data)
+		if err != nil {
+			return err
+		}
+		return libos.CreateFile(groupRouterFile, raw)
+	}
+
+	// Read existing file
+	raw, err := os.ReadFile(groupRouterFile)
+	if err != nil {
+		return fmt.Errorf("read group router: %w", err)
+	}
+
+	txt := string(raw)
+
+	if strings.Contains(txt, groupFuncHeader) {
+		// Group function exists — add route line inside it
+		routeLine := fmt.Sprintf("\n\t%s.%s(\"%s\", h.%s()).Name(\"%s\")",
+			groupRoute, methodTitle, routerPath, opsID, opsID)
+
+		return generate.InsertBeforePackageCloser(groupRouterFile, groupFuncHeader, routeLine)
+	}
+
+	// Group function doesn't exist — append new group function + V1 call
+	// First add the V1 call
+	v1Call := fmt.Sprintf("\n\t%s(r, h)", groupRoute)
+	v1Header := "func V1(r *fiber.App, h *handlerv1.Handler) {"
+	err = generate.InsertBeforePackageCloser(groupRouterFile, v1Header, v1Call)
+	if err != nil {
+		return fmt.Errorf("add V1 call: %w", err)
+	}
+
+	// Then append the new group function
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("\nfunc %s(r *fiber.App, h *handlerv1.Handler) {\n", groupRoute))
+	sb.WriteString(fmt.Sprintf("\t%s := r.Group(\"%s\")\n", groupRoute, groupRoutePath))
+	sb.WriteString(fmt.Sprintf("\t%s.%s(\"%s\", h.%s()).Name(\"%s\")\n",
+		groupRoute, methodTitle, routerPath, opsID, opsID))
+	sb.WriteString("}\n")
+
+	return generate.AppendToFile(groupRouterFile, sb.String())
+}
+
+
+// --- helper functions ---
+
+func buildReturnTypeString(types []PortServiceReturnType) string {
+	if len(types) == 0 {
+		return ""
+	}
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = t.Type
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+func buildParamString(params []PortServiceMethodParams) string {
+	if len(params) == 0 {
+		return ""
+	}
+	parts := make([]string, len(params))
+	for i, p := range params {
+		parts[i] = fmt.Sprintf("%s %s", p.Name, p.Type)
+	}
+	return ", " + strings.Join(parts, ", ")
+}
+
+func buildReturnValues(types []PortServiceReturnType) string {
+	if len(types) == 0 {
+		return ""
+	}
+	vals := make([]string, len(types))
+	for i, t := range types {
+		if t.Type == "error" {
+			vals[i] = "nil"
+		} else {
+			vals[i] = t.Type + "{}"
+		}
+	}
+	return strings.Join(vals, ", ")
+}

--- a/cmd/project/add/handler.go
+++ b/cmd/project/add/handler.go
@@ -3,7 +3,9 @@ package addcmd
 import (
 	"fmt"
 	"log"
+	"os"
 
+	"github.com/muhfaris/rocket/builder"
 	"github.com/muhfaris/rocket/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,30 +30,33 @@ var (
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			openapifile, valid := viper.Get("openapi").(string)
-			if !valid {
+			if !valid || openapifile == "" {
 				return fmt.Errorf("path openapi (--openapi) file is required")
 			}
 
-			if openapifile == "" {
-				return fmt.Errorf("path openapi (--openapi) file is required")
+			operationID, valid := viper.Get("operationid").(string)
+			if !valid || operationID == "" {
+				return fmt.Errorf("--operationid is required")
 			}
 
-			// content, doc, err := libos.LoadOpenapi(openapifile)
-			// if err != nil {
-			// 	return err
-			// }
-			//
-			// operationid := viper.Get("operationid")
-			// if operationid == "" {
-			// 	return fmt.Errorf("--operationid is required")
-			// }
-			//
-			// ignoreDataResponse, _ := viper.Get("ignore-data-response").(bool)
-			//
-			// fmt.Println(openapifile)
-			// fmt.Println(operationid)
+			ignoreDataResponse := ""
+			if v := viper.Get("ignore-data-response"); v != nil {
+				if b, ok := v.(bool); ok && b {
+					ignoreDataResponse = "true"
+				}
+			}
 
-			return nil
+			// Use current working directory as project directory
+			wd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+
+			fmt.Println("Adding handler to project in", wd)
+			fmt.Printf("  OpenAPI spec: %s\n", openapifile)
+			fmt.Printf("  OperationId:  %s\n", operationID)
+
+			return builder.AddHandler(wd, openapifile, operationID, ignoreDataResponse)
 		},
 	}
 )

--- a/cmd/project/add/handler.go
+++ b/cmd/project/add/handler.go
@@ -29,24 +29,21 @@ var (
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			openapifile, valid := viper.Get("openapi").(string)
-			if !valid || openapifile == "" {
-				return fmt.Errorf("path openapi (--openapi) file is required")
+			openapifile, err := cmd.Flags().GetString("openapi")
+			if err != nil || openapifile == "" {
+				return fmt.Errorf("--openapi flag is required")
 			}
 
-			operationID, valid := viper.Get("operationid").(string)
-			if !valid || operationID == "" {
-				return fmt.Errorf("--operationid is required")
+			operationID, err := cmd.Flags().GetString("operationid")
+			if err != nil || operationID == "" {
+				return fmt.Errorf("--operationid flag is required")
 			}
 
 			ignoreDataResponse := ""
-			if v := viper.Get("ignore-data-response"); v != nil {
-				if b, ok := v.(bool); ok && b {
-					ignoreDataResponse = "true"
-				}
+			if v, _ := cmd.Flags().GetBool("ignore-data-response"); v {
+				ignoreDataResponse = "true"
 			}
 
-			// Use current working directory as project directory
 			wd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("get working directory: %w", err)

--- a/shared/generate/append.go
+++ b/shared/generate/append.go
@@ -1,0 +1,97 @@
+package generate
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// AppendToFile appends content to the end of a file, creating it if missing.
+func AppendToFile(filepath, content string) error {
+	f, err := os.OpenFile(filepath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", filepath, err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Errorf("write %s: %w", filepath, err)
+	}
+	return nil
+}
+
+// InsertBeforeLastClosingBrace reads a file and inserts content before the final `}`.
+// SIMPLIFICATION: naive last-`}`-in-file search. If the file has a top-level closing
+// brace that isn't what we want (e.g. a struct literal at end), this will misfire.
+// Upgrade path: use go/ast with go/parser + go/printer.
+func InsertBeforeLastClosingBrace(filepath, content string) error {
+	raw, err := os.ReadFile(filepath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", filepath, err)
+	}
+
+	txt := string(raw)
+	idx := strings.LastIndex(txt, "}")
+	if idx == -1 {
+		return fmt.Errorf("no closing brace found in %s", filepath)
+	}
+
+	// Insert content before the closing brace (preserve the brace on its own line)
+	before := txt[:idx]
+	after := txt[idx:]
+	out := before + strings.TrimRight(content, "\n") + "\n" + after
+
+	if err := os.WriteFile(filepath, []byte(out), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", filepath, err)
+	}
+	return nil
+}
+
+// InsertBeforePackageCloser inserts content before the closing brace of a specific
+// top-level declaration identified by its leading text (e.g. "type Service interface {").
+// SIMPLIFICATION: finds the first matching declaration header, then its matching `}`
+// using brace counting. Works for simple generated code; may misfire on complex hand-edited code.
+func InsertBeforePackageCloser(filepath, declarationHeader, content string) error {
+	raw, err := os.ReadFile(filepath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", filepath, err)
+	}
+
+	txt := string(raw)
+	startIdx := strings.Index(txt, declarationHeader)
+	if startIdx == -1 {
+		return fmt.Errorf("declaration %q not found in %s", declarationHeader, filepath)
+	}
+
+	// Find the matching closing brace by counting braces
+	braceCount := 0
+	inDecl := false
+	insertIdx := -1
+
+	for i := startIdx; i < len(txt); i++ {
+		ch := txt[i]
+		if ch == '{' {
+			braceCount++
+			inDecl = true
+		} else if ch == '}' {
+			braceCount--
+			if inDecl && braceCount == 0 {
+				insertIdx = i
+				break
+			}
+		}
+	}
+
+	if insertIdx == -1 {
+		return fmt.Errorf("could not find closing brace for %q in %s", declarationHeader, filepath)
+	}
+
+	before := txt[:insertIdx]
+	after := txt[insertIdx:]
+	out := before + strings.TrimRight(content, "\n") + "\n" + after
+
+	if err := os.WriteFile(filepath, []byte(out), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", filepath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds the ability to incrementally add new endpoints to an existing generated project without regenerating everything from scratch.

- New shared/generate/append.go — Go file appenders (append to end, insert before closing brace, insert before package-level closer)
- New builder/hexagonal/add_handler.go — single-endpoint generation: handler, presenter, domain, port service, service impl, router
- New builder/add_handler.go — bridge from CLI to hexagonal, reads rocket.yaml for project context
- Updated cmd/project/add/handler.go — wired the RunE, replaces the previous commented-out skeleton

Usage: cd <project> && rocket add handler \
  --openapi spec.yaml --operationid CreateUser